### PR TITLE
Add error for missing controllers_brought field

### DIFF
--- a/backend/app/Http/Controllers/BeaconController.php
+++ b/backend/app/Http/Controllers/BeaconController.php
@@ -57,7 +57,7 @@ class BeaconController extends Controller
         $beacon = Beacon::create($beaconRequest);
 
         // Add host as the first attendee
-        Attendee::create([
+        $attendee = Attendee::create([
             'beacon_id' => $beacon->id,
             'user_id' => $beacon->host_id,
             'controllers_brought' => $beaconRequest['controllers_brought'],
@@ -71,7 +71,7 @@ class BeaconController extends Controller
         event(new BeaconCreated($beaconJson));
 
         // Returns data on the new beacon created and a success status code
-        return response()->json(['data' => $beaconJson], 201); // 201 Request fulfilled and new resource created
+        return response()->json(['data' => ['beacon' => $beaconJson, 'attendee' => $attendee]], 201); // 201 Request fulfilled and new resource created
     }
 
     /**

--- a/backend/app/Http/Requests/BeaconPostRequest.php
+++ b/backend/app/Http/Requests/BeaconPostRequest.php
@@ -4,11 +4,13 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class BeaconPostRequest extends FormRequest {
+class BeaconPostRequest extends FormRequest
+{
     /**
      * Determine if the user is authorized to make this request.
      */
-    public function authorize(): bool {
+    public function authorize(): bool
+    {
         return true;
     }
 
@@ -17,9 +19,10 @@ class BeaconPostRequest extends FormRequest {
      *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */
-    public function rules(): array {
+    public function rules(): array
+    {
         return [
-            'host_id' => 'string',
+            'host_id' => 'required|string',
             'game_title' => 'required|string',
             'game_image' => 'required|string',
             'console' => 'required|string',
@@ -30,8 +33,9 @@ class BeaconPostRequest extends FormRequest {
             'street_address' => 'required|string',
             'latitude' => 'required|numeric|between:-90,90|decimal:5,20',
             'longitude' => 'required|numeric|between:-180,180|decimal:5,20',
-            'players_wanted' => 'integer',
-            'controllers_wanted' => 'integer'
+            'players_wanted' => 'integer|gte:1',
+            'controllers_wanted' => 'integer',
+            'controllers_brought' => 'required|integer',
         ];
     }
 }


### PR DESCRIPTION
plus 
- post beacons api returns beacon and attendee data that was just created back for verification purposes
- players_wanted is required to be at least 1 person. cannot be zero